### PR TITLE
Add Safe contract version retrieval function

### DIFF
--- a/packages/picosafe/src/account-state.ts
+++ b/packages/picosafe/src/account-state.ts
@@ -1001,8 +1001,8 @@ function getVersion<A = void, O extends MaybeLazy<A> | undefined = undefined>(
 		// Extract the string data starting after the length field
 		const stringHex = raw.slice(130, 130 + length * 2);
 
-		// Convert hex to string
-		const version = Buffer.from(stringHex, "hex").toString("utf8");
+		// Convert hex to string using Ox Hex.toString (browser and Node compatible)
+		const version = HexUtils.toString(`0x${stringHex}` as Hex);
 
 		// Verify the version if requested
 		if (

--- a/packages/picosafe/src/safe-contracts.ts
+++ b/packages/picosafe/src/safe-contracts.ts
@@ -9,6 +9,12 @@ type SafeContracts =
 	| "MultiSendCallOnly"
 	| "CreateCall";
 
+/**
+ * Supported Safe contract versions by PicoSafe SDK.
+ * The SDK is tested and compatible with these specific versions.
+ */
+const SUPPORTED_SAFE_VERSIONS = ["1.4.1"] as const;
+
 const V141_ADDRESSES: Record<SafeContracts, Address> = {
 	SafeProxyFactory: "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
 	Safe: "0x41675C099F32341bf84BFc5382aF534df5C7461a",
@@ -20,4 +26,4 @@ const V141_ADDRESSES: Record<SafeContracts, Address> = {
 } as const;
 
 export type { SafeContracts };
-export { V141_ADDRESSES };
+export { V141_ADDRESSES, SUPPORTED_SAFE_VERSIONS };

--- a/packages/picosafe/src/signature-validation.ts
+++ b/packages/picosafe/src/signature-validation.ts
@@ -159,10 +159,9 @@ function adjustEthSignSignature(
  * @param dataHash - The hash of the data that was signed
  * @returns Promise resolving to validation result with recovered signer
  * @returns result.valid - True if recovered signer matches expected signer
- * @returns result.validatedSigner - The address recovered from the signature
+ * @returns result.validatedSigner - The address recovered from the signature (present when recovery succeeds, regardless of validity)
  * @returns result.signature - The original signature object
- * @returns result.error - Error if the signature is invalid
- * @throws {Error} If the signature is invalid (invalid r, s values) or the v-byte is not 27/28
+ * @returns result.error - Error object when signature validation fails (invalid r/s values, v-byte not 27/28, or recovery failure). Callers should check this field rather than expecting exceptions.
  *
  * Note: This function strictly expects ECDSA signatures with v = 27 or 28.
  * eth_sign signatures with v = 31/32 are handled by {@link validateSignature},
@@ -182,7 +181,10 @@ function adjustEthSignSignature(
  *
  * const result = await isValidECDSASignature(signature, txHash);
  * console.log('Valid:', result.valid);
- * console.log('Recovered signer:', result.validatedSigner);
+ * if (result.validatedSigner) {
+ *   console.log('Recovered signer:', result.validatedSigner);
+ *   // Can inspect recovered address even if valid is false
+ * }
  * ```
  */
 async function isValidECDSASignature(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read a Safe contract’s version for an address, with optional verification against supported SDK versions, immediate or lazy calls, and block-specific queries.
  * Exposes the SDK’s list of supported Safe versions.

* **Bug Fixes / Behavior**
  * Stricter signature pre-validation to reject invalid v-bytes (27/28 expected); related docs clarified.

* **Tests**
  * Added comprehensive tests for version retrieval, verification options, lazy calls, block queries, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->