### PR TITLE
fix: address review findings

### DIFF
--- a/packages/anvil-manager/src/test-utils.ts
+++ b/packages/anvil-manager/src/test-utils.ts
@@ -102,27 +102,8 @@ const cleanupAnvilProcess = () => {
 };
 
 // Handle various termination signals for proper cleanup
+// Note: Consumers should use test framework hooks (e.g., afterAll) for reliable cleanup.
+// These handlers provide a fallback for SIGINT/SIGTERM scenarios.
 process.on("exit", cleanupAnvilProcess);
 process.on("SIGINT", cleanupAnvilProcess);
 process.on("SIGTERM", cleanupAnvilProcess);
-
-// Also handle unexpected errors that might skip normal cleanup
-process.on("uncaughtException", (error) => {
-	console.error(
-		"Uncaught exception in test, cleaning up Anvil process:",
-		error,
-	);
-	cleanupAnvilProcess();
-	// Exit with error code to ensure controlled shutdown
-	process.exit(1);
-});
-
-process.on("unhandledRejection", (reason, _promise) => {
-	console.error(
-		"Unhandled rejection in test, cleaning up Anvil process:",
-		reason,
-	);
-	cleanupAnvilProcess();
-	// Exit with error code to ensure controlled shutdown
-	process.exit(1);
-});

--- a/packages/picosafe/src/account-state.ts
+++ b/packages/picosafe/src/account-state.ts
@@ -846,9 +846,10 @@ function getModulesPaginated<
 		// Remove 0x prefix for slicing
 		const hex = result.slice(2);
 
-		// Decode 'next' address (bytes32 padded)
-		const next =
+		// Decode 'next' address (bytes32 padded) and normalize to checksum
+		const nextRaw =
 			`0x${hex.slice(MODULE_NEXT_OFFSET_START, MODULE_NEXT_OFFSET_END).slice(-ADDRESS_HEX_LENGTH)}` as Address;
+		const next = OxAddress.checksum(nextRaw);
 
 		// Decode array length
 		const arrayLength = Number.parseInt(

--- a/packages/picosafe/src/deployment.ts
+++ b/packages/picosafe/src/deployment.ts
@@ -364,17 +364,25 @@ async function deploySafeAccount(
 		{
 			safeAddress: predictedAddress,
 			deploymentConfig: {
-				owners,
+				owners: owners.map((owner) => OxAddress.checksum(owner)),
 				threshold,
-				UNSAFE_DELEGATECALL_to,
+				UNSAFE_DELEGATECALL_to: UNSAFE_DELEGATECALL_to
+					? OxAddress.checksum(UNSAFE_DELEGATECALL_to)
+					: UNSAFE_DELEGATECALL_to,
 				UNSAFE_DELEGATECALL_data,
-				fallbackHandler,
-				paymentToken,
+				fallbackHandler: fallbackHandler
+					? OxAddress.checksum(fallbackHandler)
+					: fallbackHandler,
+				paymentToken: paymentToken
+					? OxAddress.checksum(paymentToken)
+					: paymentToken,
 				payment,
-				paymentReceiver,
+				paymentReceiver: paymentReceiver
+					? OxAddress.checksum(paymentReceiver)
+					: paymentReceiver,
 				saltNonce,
-				singleton,
-				proxyFactory,
+				singleton: OxAddress.checksum(singleton),
+				proxyFactory: OxAddress.checksum(proxyFactory),
 			},
 		},
 	);

--- a/packages/picosafe/src/multisend.ts
+++ b/packages/picosafe/src/multisend.ts
@@ -100,6 +100,13 @@ function encodeMultiSendCall(
 	// ABI encoding would add. Therefore we manually build the bytes sequence below
 	// instead of using high-level Abi helpers.
 	for (const tx of transactions) {
+		// Validate that data is hex-prefixed
+		if (!tx.data.startsWith("0x")) {
+			throw new Error(
+				`Transaction data must be hex-prefixed (start with "0x"). Received: ${tx.data.slice(0, 10)}...`,
+			);
+		}
+
 		const encoded = Bytes.fromArray([
 			...Bytes.from(
 				Bytes.fromNumber(

--- a/packages/picosafe/src/safe-signatures.ts
+++ b/packages/picosafe/src/safe-signatures.ts
@@ -555,6 +555,8 @@ async function validateSignaturesForSafe(
 		safeConfig?.owners ?? (await getOwners(provider, { safeAddress }));
 	const requiredSignatures =
 		safeConfig?.threshold ?? (await getThreshold(provider, { safeAddress }));
+	// Convert owners array to Set for O(1) lookup instead of O(n) with includes()
+	const safeOwnersSet = new Set<Address>(safeOwners);
 	const seenOwners = new Set<Address>();
 
 	const signatures = Array.isArray(validationParams.signatures)
@@ -600,7 +602,7 @@ async function validateSignaturesForSafe(
 		if (
 			result.valid &&
 			result.validatedSigner &&
-			safeOwners.includes(result.validatedSigner) &&
+			safeOwnersSet.has(result.validatedSigner) &&
 			!seenOwners.has(result.validatedSigner)
 		) {
 			validSignaturesCount++;


### PR DESCRIPTION
High severity:
- Fix module pagination in getDisableModuleTransaction to handle Safes with >100 modules

Medium severity:
- Remove aggressive global error handlers that could kill consuming test runners
- Normalize 'next' address in getModulesPaginated for consistency

Low severity:
- Optimize validateSignaturesForSafe with Set for O(1) owner lookups
- Normalize all addresses in deploySafeAccount return metadata
- Add validation for hex-prefixed data in multisend encoder

All tests passing (225 passed), type checking clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Reliable module disabling across paginated module lists.
  - Normalize/checksum addresses in deployments and pagination pointers to avoid casing-related issues.
  - Validate multisend transaction data is 0x-prefixed with clearer error messages.

- Performance
  - Faster Safe owner lookups during signature verification.

- Chores/Tests
  - Simplified test cleanup handlers to rely on test framework hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->