### PR TITLE
chore: standardize brand name to lowercase 'picosafe'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CLAUDE.md
 
-This file provides comprehensive guidance to Claude Code (claude.ai/code) for efficiently working with the PicoSafe SDK codebase. It defines coding standards, workflow procedures, and architectural patterns to ensure consistent, high-quality contributions.
+This file provides comprehensive guidance to Claude Code (claude.ai/code) for efficiently working with the picosafe SDK codebase. It defines coding standards, workflow procedures, and architectural patterns to ensure consistent, high-quality contributions.
 
 ## Project Overview
 
-PicoSafe is a minimalistic but advanced TypeScript SDK for Safe Smart Account contracts (v1.4.1+). The SDK follows a one-action-one-function principle, providing a simple API for Safe operations without managing keys or connections.
+picosafe is a minimalistic but advanced TypeScript SDK for Safe Smart Account contracts (v1.4.1+). The SDK follows a one-action-one-function principle, providing a simple API for Safe operations without managing keys or connections.
 
-**Library Dependencies**: The SDK uses [Ox](https://oxlib.sh) as its core Ethereum library for ABI encoding, address manipulation, and cryptographic operations. Ox provides a minimal, type-safe API that aligns with PicoSafe's philosophy of simplicity and correctness.
+**Library Dependencies**: The SDK uses [Ox](https://oxlib.sh) as its core Ethereum library for ABI encoding, address manipulation, and cryptographic operations. Ox provides a minimal, type-safe API that aligns with picosafe's philosophy of simplicity and correctness.
 
 ## Key Commands
 
@@ -30,9 +30,9 @@ Use the `-w` flag with the package name to run commands for a specific package:
 
 ```bash
 # Development
-npm run dev -w @volga/picosafe       # Watch mode development build for PicoSafe
+npm run dev -w @volga/picosafe       # Watch mode development build for picosafe
 npm run build -w @volga/picosafe     # Build the SDK (CJS and ESM)
-npm run typecheck -w @volga/picosafe # TypeScript type checking for PicoSafe only
+npm run typecheck -w @volga/picosafe # TypeScript type checking for picosafe only
 
 # Testing
 npm run test -w @volga/picosafe     # Run tests with automated Anvil setup
@@ -208,7 +208,7 @@ The test suite covers all SDK functionality including deployment, transactions, 
 
 ### Testing with Anvil
 
-The PicoSafe package includes an automated Anvil setup for testing. When running tests:
+The picosafe package includes an automated Anvil setup for testing. When running tests:
 
 - Tests automatically start and stop Anvil with pre-deployed Safe 1.4.1 contracts
 - The setup is handled by `packages/picosafe/tests/setup-anvil.ts`
@@ -290,7 +290,7 @@ Examples serve as both documentation and learning tools. They should showcase li
 
 ### Core Principles for Examples
 
-1. **Focus on Library APIs**: Examples should highlight PicoSafe functions, not boilerplate setup
+1. **Focus on Library APIs**: Examples should highlight picosafe functions, not boilerplate setup
 2. **Minimize Noise**: Remove excessive console.logs, decorative output, and verbose formatting
 3. **Runnable but Readable**: Primary purpose is to be read and understood, secondary is execution
 4. **Concise Output**: Only log essential information (addresses, transaction hashes, success confirmations)
@@ -300,7 +300,7 @@ Examples serve as both documentation and learning tools. They should showcase li
 #### Setup Abstraction
 
 - **Use shared setup modules**: Extract repetitive client configuration to `setup.ts`
-- **Comment non-library code**: Clearly indicate when code is standard Ethereum setup vs PicoSafe-specific
+- **Comment non-library code**: Clearly indicate when code is standard Ethereum setup vs picosafe-specific
 - **Type explicitly**: Add explicit type annotations to avoid complex type inference issues
 
 Example setup module:
@@ -310,7 +310,7 @@ export function setupClients(rpcUrl: string): {
   walletClient: WalletClient<Transport, Chain, Account>
   publicClient: PublicClient
 } {
-  // Standard Viem setup - not PicoSafe specific
+  // Standard Viem setup - not picosafe specific
   // Implementation details...
 }
 ```
@@ -399,7 +399,7 @@ This pattern is implemented using the `wrapEthereumTransaction` utility from `ut
 
 ### Critical Safety Requirements
 
-PicoSafe handles financial assets where mistakes can lead to irreversible loss of funds. Every change must be approached with extreme caution:
+picosafe handles financial assets where mistakes can lead to irreversible loss of funds. Every change must be approached with extreme caution:
 
 1. **Test Everything Meticulously**: All functionality must have comprehensive test coverage including edge cases, error conditions, and adversarial inputs
 2. **Prevent Footguns**: Design APIs to make dangerous operations impossible or extremely explicit. Focus on operations allowed by Safe contracts but potentially dangerous:
@@ -459,6 +459,10 @@ Before any code changes:
 
 ## Developer Notes
 
+- **Brand Name Convention**:
+  - Always use lowercase "picosafe" when referring to the project, SDK, or brand
+  - TypeScript type names follow PascalCase with "Picosafe" prefix (e.g., `PicosafeSignature`, `PicosafeRpcBlockIdentifier`)
+  - This applies to documentation, code comments, JSDoc, error messages, and all user-facing text
 - **Type Management**:
   - Keep the types in `types.ts`, unless it's only crucial for that particular file
 - **Ox Library Usage**:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PicoSafe
+# picosafe
 
 A minimalistic but advanced TypeScript SDK for Safe Smart Account contracts (v1.4.1), providing a simple API for Safe operations without managing keys or connections.
 
@@ -8,7 +8,7 @@ A minimalistic but advanced TypeScript SDK for Safe Smart Account contracts (v1.
 
 ## Overview
 
-PicoSafe provides modules for:
+picosafe provides modules for:
 
 - Account deployment and management
 - Transaction building, signing, and execution
@@ -25,7 +25,7 @@ npm install picosafe
 
 ## Basic Usage
 
-PicoSafe works with any EIP-1193 provider. You can use Viem, Ethers, or any other library that provides an EIP-1193 compatible provider.
+picosafe works with any EIP-1193 provider. You can use Viem, Ethers, or any other library that provides an EIP-1193 compatible provider.
 
 ### Using with Viem
 
@@ -118,7 +118,7 @@ The SDK requires an EIP-1193 compatible provider that supports:
 
 This is a monorepo managed with npm workspaces, containing:
 
-- `packages/picosafe` - The main PicoSafe SDK
+- `packages/picosafe` - The main picosafe SDK
 - `packages/anvil-manager` - Anvil process management for tests and examples
 - `packages/safe-genesis` - Genesis configuration with pre-deployed Safe v1.4.1 contracts
 - `packages/examples` - Example applications demonstrating SDK usage

--- a/packages/anvil-manager/README.md
+++ b/packages/anvil-manager/README.md
@@ -16,7 +16,7 @@ A TypeScript library for managing Anvil (Foundry) instances in tests and example
 
 We chose to build anvil-manager instead of using existing solutions like [prool](https://github.com/wevm/prool) for several key reasons:
 
-1. **Simplicity**: Our implementation is simpler and more direct, which aligns with PicoSafe's minimalistic philosophy. We provide straightforward process management without unnecessary abstractions.
+1. **Simplicity**: Our implementation is simpler and more direct, which aligns with picosafe's minimalistic philosophy. We provide straightforward process management without unnecessary abstractions.
 
 2. **Specific Purpose**: We only need Anvil management, not the full suite of capabilities that prool offers (bundlers, multiple instance types, etc.). This focused approach keeps our codebase lean and easy to understand.
 

--- a/packages/examples/2-safe-transaction-execution.ts
+++ b/packages/examples/2-safe-transaction-execution.ts
@@ -12,7 +12,7 @@ import { withExampleScene } from "./example-scene.js";
  * Demonstrates the full Safe transaction workflow:
  * Build transaction → Sign → Execute
  *
- * Shows how PicoSafe separates transaction building, signing, and execution
+ * Shows how picosafe separates transaction building, signing, and execution
  * for maximum flexibility in multi-signature workflows.
  */
 

--- a/packages/examples/3-batch-safe-deployment-with-multisend.ts
+++ b/packages/examples/3-batch-safe-deployment-with-multisend.ts
@@ -11,7 +11,7 @@ import { withExampleScene } from "./example-scene.js";
 /**
  * Example: Batch Safe Deployment with MultiSend
  *
- * Demonstrates PicoSafe's composability by deploying multiple Safe accounts
+ * Demonstrates picosafe's composability by deploying multiple Safe accounts
  * in a single transaction using the MultiSend contract. Shows how to:
  * - Use rawTransaction data from deploySafeAccount()
  * - Batch operations with encodeMultiSendCall()

--- a/packages/examples/4-multiple-transfers-with-multisend.ts
+++ b/packages/examples/4-multiple-transfers-with-multisend.ts
@@ -10,7 +10,7 @@ import { withExampleScene } from "./example-scene.js";
 /**
  * Example: Multiple Transfers with Automatic MultiSend
  *
- * Shows PicoSafe's automatic MultiSend handling when passing multiple transactions
+ * Shows picosafe's automatic MultiSend handling when passing multiple transactions
  * to buildSafeTransaction(). Demonstrates batching ETH and ERC20 transfers in a
  * single atomic Safe transaction without manual MultiSend encoding.
  */

--- a/packages/examples/example-scene.ts
+++ b/packages/examples/example-scene.ts
@@ -37,7 +37,7 @@ import { type PrivateKeyAccount, privateKeyToAccount } from "viem/accounts";
 import { anvil } from "viem/chains";
 
 /**
- * Pre-configured test environment for PicoSafe examples
+ * Pre-configured test environment for picosafe examples
  */
 export type ExampleScene<
 	TOptions extends ExampleSceneOptions = ExampleSceneOptions,
@@ -205,7 +205,7 @@ async function collectSignaturesForSafe(
  * await withExampleScene(async (scene) => {
  *   const { walletClient, publicClient, safes, accounts } = scene;
  *
- *   // Your example code here, focusing purely on PicoSafe functionality
+ *   // Your example code here, focusing purely on picosafe functionality
  *   const safeTx = await buildSafeTransaction(
  *     walletClient,
  *     safes.singleOwner,

--- a/packages/examples/run-all-examples.sh
+++ b/packages/examples/run-all-examples.sh
@@ -8,7 +8,7 @@ set -euo pipefail  # Exit on any error
 # Change to the script's directory to ensure paths are resolved correctly
 cd "$(dirname "$0")"
 
-echo "🚀 Running all PicoSafe examples..."
+echo "🚀 Running all picosafe examples..."
 echo "=================================="
 echo ""
 

--- a/packages/picosafe/src/account-state.ts
+++ b/packages/picosafe/src/account-state.ts
@@ -878,11 +878,11 @@ function getModulesPaginated<
  *
  * @remarks
  * This function calls the `VERSION()` method on the Safe contract to get the version string.
- * By default, it validates that the returned version is one of the supported versions by PicoSafe.
+ * By default, it validates that the returned version is one of the supported versions by picosafe.
  * You can disable this validation by setting `verify: false` in the options.
  *
  * The verification helps ensure you're working with a Safe contract version that's compatible
- * with PicoSafe's functionality and has been tested against this SDK.
+ * with picosafe's functionality and has been tested against this SDK.
  *
  * @param provider - An EIP-1193 compliant provider used to perform the eth_call
  * @param params - Parameters for the version read
@@ -891,9 +891,9 @@ function getModulesPaginated<
  *                  - `lazy`: If true, returns a wrapped call object instead of executing immediately
  *                  - `block`: Block number or tag to query at (defaults to "latest")
  *                  - `data`: Optional additional data to attach to the wrapped call
- *                  - `verify`: If true (default), validates that the version is supported by PicoSafe
+ *                  - `verify`: If true (default), validates that the version is supported by picosafe
  * @returns The version string of the Safe contract, or a wrapped call object
- * @throws {Error} If the eth_call fails or if verify is true and the version is not supported by PicoSafe
+ * @throws {Error} If the eth_call fails or if verify is true and the version is not supported by picosafe
  * @example
  * ```typescript
  * import { createPublicClient, http } from "viem";
@@ -977,7 +977,7 @@ function getVersion<A = void, O extends MaybeLazy<A> | undefined = undefined>(
 		) {
 			throw new Error(
 				`Unsupported Safe version "${version}" at ${safeAddress}. ` +
-					`PicoSafe only supports Safe versions: ${SUPPORTED_SAFE_VERSIONS.join(", ")}. ` +
+					`picosafe only supports Safe versions: ${SUPPORTED_SAFE_VERSIONS.join(", ")}. ` +
 					"To get the raw version without validation, use { verify: false }.",
 			);
 		}

--- a/packages/picosafe/src/safe-contracts.ts
+++ b/packages/picosafe/src/safe-contracts.ts
@@ -17,7 +17,7 @@ type SafeContracts =
 	| "CreateCall";
 
 /**
- * Supported Safe contract versions by PicoSafe SDK.
+ * Supported Safe contract versions by picosafe SDK.
  * The SDK is tested and compatible with these specific versions.
  */
 const SUPPORTED_SAFE_VERSIONS = ["1.4.1"] as const;

--- a/packages/picosafe/src/safe-signatures.ts
+++ b/packages/picosafe/src/safe-signatures.ts
@@ -211,7 +211,7 @@ function readDynamicData(
  * Decodes Safe signature bytes back into individual signature components
  *
  * Parses the concatenated signature format used by Safe contracts back into
- * an array of individual {@link PicoSafeSignature} objects. This function performs
+ * an array of individual {@link PicosafeSignature} objects. This function performs
  * signature recovery for ECDSA signatures to populate the signer address field.
  *
  * The function handles all Safe signature types as defined by {@link SignatureTypeVByte}:
@@ -234,7 +234,7 @@ function readDynamicData(
  *                     - eth_sign: Safe applies "\x19Ethereum Signed Message:\n32" prefix internally
  *                     - Contract: Passed to isValidSignature
  *                     - Approved: Checked against approvedHashes mapping
- * @returns Array of {@link PicoSafeSignature} objects with recovered signer addresses
+ * @returns Array of {@link PicosafeSignature} objects with recovered signer addresses
  * @throws {Error} If signature data is malformed, has invalid type bytes, or offsets are invalid
  * @example
  * ```typescript

--- a/packages/picosafe/tests/README.md
+++ b/packages/picosafe/tests/README.md
@@ -1,6 +1,6 @@
-# PicoSafe Testing Guide
+# picosafe Testing Guide
 
-This directory contains comprehensive integration tests for the PicoSafe SDK.
+This directory contains comprehensive integration tests for the picosafe SDK.
 
 ## Prerequisites
 

--- a/packages/picosafe/vitest.config.ts
+++ b/packages/picosafe/vitest.config.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Vitest configuration for PicoSafe integration tests.
+ * @fileoverview Vitest configuration for picosafe integration tests.
  *
  * Configuration choices explained:
  * - globals: true - Enables global test functions (describe, it, expect) without imports

--- a/packages/test-contracts/package.json
+++ b/packages/test-contracts/package.json
@@ -2,7 +2,7 @@
 	"name": "@volga/test-contracts",
 	"version": "0.0.1",
 	"private": true,
-	"description": "Test contracts for PicoSafe examples",
+	"description": "Test contracts for picosafe examples",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Standardizes all brand references from "PicoSafe" to "picosafe" for consistency
- Updates documentation, code comments, JSDoc, error messages, and examples
- TypeScript type names remain PascalCase with "Picosafe" prefix (e.g., `PicosafeSignature`)
- Adds brand naming convention to CLAUDE.md Developer Notes

## Changes
- CLAUDE.md: Updated all references and added naming convention guidelines
- README.md: Updated project title and descriptions
- Source files: Updated JSDoc comments and error messages
- Examples: Updated comments and documentation
- Test documentation: Updated README titles

## Test plan
- [x] All linting checks pass (`npm run check`)
- [x] All type checks pass (`npm run typecheck`)
- [x] No behavioral changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)